### PR TITLE
all-but-root-statistics

### DIFF
--- a/src/ontology/aio.Makefile
+++ b/src/ontology/aio.Makefile
@@ -51,7 +51,10 @@ components-from-new-input: remove-old-input
 	make components/aio-component.owl
 
 aio.db: aio.owl # requires that rdftab and relation0graph have been installed locally and are on the default path
-	poetry run semsql make $@
+# truly local build saying ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
+# or create with docker run  -v $PWD:/work -w /work -ti linkml/semantic-sql semsql make aio.db
+	#poetry run semsql make $@
+	docker run  -v $$PWD:/work -w /work -ti linkml/semantic-sql semsql make $@
 	rm -rf aio-relation-graph.tsv.gz
 
 aio-root-statistics.tsv: aio.db # could use sqlite:obo:aio if the file in the BBOP S3 bucket is new enough


### PR DESCRIPTION
```shell
poetry run runoak --input aio.db --help
```

> ```
> Traceback (most recent call last):
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/bin/runoak", line 5, in <module>
>     from oaklib.cli import main
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/oaklib/__init__.py", line 7, in <module>
>     from oaklib.interfaces import BasicOntologyInterface  # noqa:F401
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/oaklib/interfaces/__init__.py", line 1, in <module>
>     from oaklib.interfaces.basic_ontology_interface import BasicOntologyInterface
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/oaklib/interfaces/basic_ontology_interface.py", line 12, in <module>
>     from sssom.parsers import parse_sssom_table, to_mapping_set_document
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/sssom/__init__.py", line 18, in <module>
>     from .util import (  # noqa:401
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/sssom/util.py", line 29, in <module>
>     import pandas as pd
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/__init__.py", line 22, in <module>
>     from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/compat/__init__.py", line 18, in <module>
>     from pandas.compat.numpy import (
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/compat/numpy/__init__.py", line 4, in <module>
>     from pandas.util.version import Version
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/util/__init__.py", line 2, in <module>
>     from pandas.util._decorators import (  # noqa:F401
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/util/_decorators.py", line 14, in <module>
>     from pandas._libs.properties import cache_readonly
>   File "/home/mark/.cache/pypoetry/virtualenvs/artificial-intelligence-ontology-7BQOAQ2D-py3.10/lib/python3.10/site-packages/pandas/_libs/__init__.py", line 13, in <module>
>     from pandas._libs.interval import Interval
>   File "pandas/_libs/interval.pyx", line 1, in init pandas._libs.interval
> ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
> ```