### PR TITLE
Fail QC on ROBOT report errors

### DIFF
--- a/src/ontology/aio-odk.yaml
+++ b/src/ontology/aio-odk.yaml
@@ -31,7 +31,7 @@ robot_java_args: '-Xmx10G'
 robot_report:
   ensure_owl2dl_profile: false
   release_reports: true
-  fail_on: none
+  fail_on: error
   use_labels: false
   custom_profile: false
   report_on:

--- a/src/ontology/aio.Makefile
+++ b/src/ontology/aio.Makefile
@@ -12,6 +12,13 @@ all-extras-clean: clean clean-extras remove-old-input
 
 all-extras-build: components-from-new-input all bridge/aio-bridge-to-upper.owl
 
+# Fail QC on ROBOT report ERRORs (matches cell-ontology, uberon, pato).
+# The source of truth for this is robot_report.fail_on in aio-odk.yaml; this
+# override makes it effective now, before the next `make update_repo`
+# regenerates the main Makefile from that config. aio.Makefile is included
+# after the generated default (REPORT_FAIL_ON = none), so this wins.
+REPORT_FAIL_ON = ERROR
+
 # Source of truth for AIO.
 # This is a ROBOT template.
 SRC_URL = 'https://docs.google.com/spreadsheets/d/1LVubUGg56YDGJ0VUdJDMNBPY8iFfissRfy4eM56bUFg/export?exportFormat=csv'


### PR DESCRIPTION
Makes QC fail on ROBOT report **errors**, instead of the current `fail_on: none` which lets every violation pass.

- `aio-odk.yaml`: `robot_report.fail_on: none` to `error` (the source of truth for when `make update_repo` regenerates the Makefile).
- `aio.Makefile`: `REPORT_FAIL_ON = ERROR` override, so it is effective now without waiting for an ODK update. `aio.Makefile` is included after the generated default, so it wins.

Precedent: cell-ontology, uberon, and pato all set `robot_report.fail_on: ERROR` while keeping the top-level `report_fail_on` off.

Safe: AIO currently reports 0 errors (10 warnings). Warnings still pass; this only blocks real errors going forward. Verified locally with `make test` on odkfull v1.6.1 ("Finished running all tests successfully").

Scoped deliberately small. The related idea of guarding the `aio-src.csv` auto-curl is a build-flow design change and is left to the de-formula work in #153.
