### PR TITLE
Add ontology-level provenance annotations and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+cff-version: 1.2.0
+message: "If you use the Artificial Intelligence Ontology (AIO), please cite the article listed under preferred-citation."
+title: "Artificial Intelligence Ontology (AIO)"
+abstract: "The Artificial Intelligence Ontology (AIO) is a systematization of artificial intelligence concepts, methodologies, and their interrelations, spanning networks, layers, functions, large language models, preprocessing, and bias."
+type: dataset
+license: CC-BY-4.0
+repository-code: "https://github.com/berkeleybop/artificial-intelligence-ontology"
+url: "https://w3id.org/aio/"
+authors:
+  - family-names: Joachimiak
+    given-names: "Marcin P."
+  - family-names: Miller
+    given-names: "Mark A."
+    orcid: "https://orcid.org/0000-0001-9076-6066"
+  - family-names: Caufield
+    given-names: "J. Harry"
+  - family-names: Ly
+    given-names: Ryan
+  - family-names: Harris
+    given-names: "Nomi L."
+  - family-names: Tritt
+    given-names: Andrew
+  - family-names: Mungall
+    given-names: "Christopher J."
+  - family-names: Bouchard
+    given-names: "Kristofer E."
+preferred-citation:
+  type: article
+  title: "The Artificial Intelligence Ontology: LLM-assisted construction of AI concept hierarchies"
+  journal: "Applied Ontology"
+  year: 2024
+  doi: "10.1177/15705838241304103"
+  authors:
+    - family-names: Joachimiak
+      given-names: "Marcin P."
+    - family-names: Miller
+      given-names: "Mark A."
+      orcid: "https://orcid.org/0000-0001-9076-6066"
+    - family-names: Caufield
+      given-names: "J. Harry"
+    - family-names: Ly
+      given-names: Ryan
+    - family-names: Harris
+      given-names: "Nomi L."
+    - family-names: Tritt
+      given-names: Andrew
+    - family-names: Mungall
+      given-names: "Christopher J."
+    - family-names: Bouchard
+      given-names: "Kristofer E."

--- a/docs/cite.md
+++ b/docs/cite.md
@@ -1,3 +1,7 @@
 # How to cite AIO
 
-TBA
+If you use the Artificial Intelligence Ontology (AIO), please cite:
+
+Joachimiak MP, Miller MA, Caufield JH, Ly R, Harris NL, Tritt A, Mungall CJ, Bouchard KE. The Artificial Intelligence Ontology: LLM-assisted construction of AI concept hierarchies. Applied Ontology. 2024. doi:10.1177/15705838241304103 (open access: arXiv:2404.03044).
+
+A machine-readable citation is available in [CITATION.cff](../CITATION.cff) in the repository root.

--- a/src/ontology/aio-annotations.ttl
+++ b/src/ontology/aio-annotations.ttl
@@ -2,9 +2,29 @@
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix obo:     <http://purl.obolibrary.org/obo/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/aio/aio.owl>
   rdf:type owl:Ontology ;
   dcterms:title "Artificial Intelligence Ontology" ;
   dcterms:license <http://creativecommons.org/licenses/by/4.0/> ;
-  dcterms:description "This ontology models classes and relationships describing deep learning networks, their component layers and activation functions, as well as potential biases." .
+  dcterms:description "The Artificial Intelligence Ontology (AIO) is a systematization of artificial intelligence concepts, methodologies, and their interrelations, spanning networks, layers, functions, large language models, preprocessing, and bias." ;
+  dcterms:created "2024-03-31"^^xsd:date ;
+  dcterms:source <https://github.com/berkeleybop/artificial-intelligence-ontology> ;
+  dcterms:creator
+    "Mark A. Miller" ,
+    "Marcin P. Joachimiak" ,
+    "J. Harry Caufield" ,
+    "Christopher J. Mungall" ;
+  dcterms:bibliographicCitation "Joachimiak MP, Miller MA, Caufield JH, Ly R, Harris NL, Tritt A, Mungall CJ, Bouchard KE. The Artificial Intelligence Ontology: LLM-assisted construction of AI concept hierarchies. Applied Ontology. 2024. doi:10.1177/15705838241304103" ;
+  rdfs:seeAlso <https://doi.org/10.1177/15705838241304103> ;
+  obo:IAO_0000700
+    <https://w3id.org/aio/Bias> ,
+    <https://w3id.org/aio/Layer> ,
+    <https://w3id.org/aio/MachineLearningTask> ,
+    <https://w3id.org/aio/MathematicalFunction> ,
+    <https://w3id.org/aio/Model> ,
+    <https://w3id.org/aio/Network> ,
+    <https://w3id.org/aio/Preprocessing> ,
+    <https://w3id.org/aio/TrainingStrategy> .

--- a/src/ontology/aio-annotations.ttl
+++ b/src/ontology/aio-annotations.ttl
@@ -28,3 +28,6 @@
     <https://w3id.org/aio/Network> ,
     <https://w3id.org/aio/Preprocessing> ,
     <https://w3id.org/aio/TrainingStrategy> .
+
+obo:IAO_0000700 rdf:type owl:AnnotationProperty ;
+  rdfs:label "has ontology root term" .


### PR DESCRIPTION
Enriches the ontology header metadata and adds a citation file, so the ontology landing page (OLS, BioPortal) and GitHub show authorship, provenance, and how to cite AIO.

**`src/ontology/aio-annotations.ttl`**
- `dcterms:description` rewritten to cover all six branches. The previous text named only deep-learning networks, layers, and bias, omitting the large language model, preprocessing, machine learning task, and model branches.
- `dcterms:creator`: the four repository contributors (Miller, Joachimiak, Caufield, Mungall), ordered by commit count.
- `dcterms:bibliographicCitation` and `rdfs:seeAlso`: the AIO paper (Applied Ontology, 2024, doi:10.1177/15705838241304103), naming all eight authors.
- `dcterms:created`, `dcterms:source`, and `obo:IAO_0000700` for the eight top-level branch roots (portable tree roots for OLS and other consumers).

**`CITATION.cff`** (new): all eight paper authors, plus the paper as `preferred-citation`. Closes #164.

Distinction: `dcterms:creator` is the four who built the repository; all eight paper authors are credited in the citation and CITATION.cff.

Validated the resulting landing page in a local OLS4 instance. These are source changes; they reach the released `aio.owl` at the next release build.
