### PR TITLE
Give subset properties rdfs:label so OLS shows names, not shortforms

### DIFF
--- a/src/ontology/aio-edit.owl
+++ b/src/ontology/aio-edit.owl
@@ -64,7 +64,7 @@ AnnotationAssertion(rdfs:label <http://www.geneontology.org/formats/oboInOwl#Sub
 
 # Annotation Property: aio:ActivationFunctionSubset (aio:ActivationFunctionSubset)
 
-AnnotationAssertion(rdfs:label aio:ActivationFunctionSubset "Activation Function Subset")
+AnnotationAssertion(rdfs:label aio:ActivationFunctionSubset "Activation Function Subset"@en)
 SubAnnotationPropertyOf(aio:ActivationFunctionSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:BiasSubset (aio:BiasSubset)
@@ -84,7 +84,7 @@ SubAnnotationPropertyOf(aio:FunctionSubset <http://www.geneontology.org/formats/
 
 # Annotation Property: aio:InstanceNormalizationLayerSubset (aio:InstanceNormalizationLayerSubset)
 
-AnnotationAssertion(rdfs:label aio:InstanceNormalizationLayerSubset "Instance Normalization Layer Subset")
+AnnotationAssertion(rdfs:label aio:InstanceNormalizationLayerSubset "Instance Normalization Layer Subset"@en)
 SubAnnotationPropertyOf(aio:InstanceNormalizationLayerSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:LayerSubset (aio:LayerSubset)

--- a/src/ontology/aio-edit.owl
+++ b/src/ontology/aio-edit.owl
@@ -64,52 +64,52 @@ AnnotationAssertion(rdfs:label <http://www.geneontology.org/formats/oboInOwl#Sub
 
 # Annotation Property: aio:ActivationFunctionSubset (aio:ActivationFunctionSubset)
 
-AnnotationAssertion(rdfs:comment aio:ActivationFunctionSubset "Activation Function Subset")
+AnnotationAssertion(rdfs:label aio:ActivationFunctionSubset "Activation Function Subset")
 SubAnnotationPropertyOf(aio:ActivationFunctionSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:BiasSubset (aio:BiasSubset)
 
-AnnotationAssertion(rdfs:comment aio:BiasSubset "Bias Subset"@en)
+AnnotationAssertion(rdfs:label aio:BiasSubset "Bias Subset"@en)
 SubAnnotationPropertyOf(aio:BiasSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:ClassSubset (aio:ClassSubset)
 
-AnnotationAssertion(rdfs:comment aio:ClassSubset "Class Subset"@en)
+AnnotationAssertion(rdfs:label aio:ClassSubset "Class Subset"@en)
 SubAnnotationPropertyOf(aio:ClassSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:FunctionSubset (aio:FunctionSubset)
 
-AnnotationAssertion(rdfs:comment aio:FunctionSubset "Function Subset"@en)
+AnnotationAssertion(rdfs:label aio:FunctionSubset "Function Subset"@en)
 SubAnnotationPropertyOf(aio:FunctionSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:InstanceNormalizationLayerSubset (aio:InstanceNormalizationLayerSubset)
 
-AnnotationAssertion(rdfs:comment aio:InstanceNormalizationLayerSubset "Instance Normalization Layer Subset")
+AnnotationAssertion(rdfs:label aio:InstanceNormalizationLayerSubset "Instance Normalization Layer Subset")
 SubAnnotationPropertyOf(aio:InstanceNormalizationLayerSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:LayerSubset (aio:LayerSubset)
 
-AnnotationAssertion(rdfs:comment aio:LayerSubset "Layer Subset"@en)
+AnnotationAssertion(rdfs:label aio:LayerSubset "Layer Subset"@en)
 SubAnnotationPropertyOf(aio:LayerSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:MachineLearningSubset (aio:MachineLearningSubset)
 
-AnnotationAssertion(rdfs:comment aio:MachineLearningSubset "Machine Learning Subset"@en)
+AnnotationAssertion(rdfs:label aio:MachineLearningSubset "Machine Learning Subset"@en)
 SubAnnotationPropertyOf(aio:MachineLearningSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:ModelSubset (aio:ModelSubset)
 
-AnnotationAssertion(rdfs:comment aio:ModelSubset "Model Subset"@en)
+AnnotationAssertion(rdfs:label aio:ModelSubset "Model Subset"@en)
 SubAnnotationPropertyOf(aio:ModelSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:NetworkSubset (aio:NetworkSubset)
 
-AnnotationAssertion(rdfs:comment aio:NetworkSubset "Network Subset"@en)
+AnnotationAssertion(rdfs:label aio:NetworkSubset "Network Subset"@en)
 SubAnnotationPropertyOf(aio:NetworkSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 # Annotation Property: aio:PreprocessingSubset (aio:PreprocessingSubset)
 
-AnnotationAssertion(rdfs:comment aio:PreprocessingSubset "Preprocessing Subset"@en)
+AnnotationAssertion(rdfs:label aio:PreprocessingSubset "Preprocessing Subset"@en)
 SubAnnotationPropertyOf(aio:PreprocessingSubset <http://www.geneontology.org/formats/oboInOwl#SubsetProperty>)
 
 


### PR DESCRIPTION
The 10 subset annotation properties carried their display name in `rdfs:comment`. OLS reads `rdfs:label`, so it fell back to the IRI shortform (e.g. `AIO_ModelSubset`) on the ontology page. This moves each name from `rdfs:comment` to `rdfs:label`.

Covers: Activation Function, Bias, Class, Function, Instance Normalization Layer, Layer, Machine Learning, Model, Network, and Preprocessing Subsets.

Same class of issue seen in MIxS: OLS displays the IRI shortform whenever an entity has no value in the configured label property.
